### PR TITLE
Fix UB in lcd_st7735_putchar

### DIFF
--- a/st7735/lcd_st7735.c
+++ b/st7735/lcd_st7735.c
@@ -201,13 +201,13 @@ Result lcd_st7735_putchar(St7735Context *ctx, LCD_Point origin, char character) 
 
   set_address(ctx, origin.x, origin.y, origin.x + char_descriptor->width - 1, origin.y + font->height - 1);
   ctx->parent.interface->gpio_write(ctx->parent.interface->handle, false, true);
-  const uint8_t *char_bitmap = &font->bitmap_table[char_descriptor->position - 1];
+  const uint8_t *char_bitmap = &font->bitmap_table[char_descriptor->position];
   for (int row = 0; row < font->height; row++) {
     for (int column = 0; column < char_descriptor->width; column++) {
       uint8_t bit = (uint8_t)(column % 8);
       char_bitmap += (uint8_t)(bit == 0);
       buffer[column] =
-          (uint16_t)((*char_bitmap & (0x01 << bit)) ? ctx->parent.foreground_color : ctx->parent.background_color);
+          (uint16_t)((char_bitmap[-1] & (0x01 << bit)) ? ctx->parent.foreground_color : ctx->parent.background_color);
     }
     write_buffer(ctx, (uint8_t *)buffer, sizeof(buffer));
   }


### PR DESCRIPTION
char_bitmap is initialised to the starting position - 1 and then in the first iteration inside loop we increment it to the starting position. Although we never access out of bound, creating an out-of-bound pointer is considered UB in C regardless, causing this code to not work in CHERI.

Have char_bitmap always be 1 over and access using [-1] would fix this UB.