### PR TITLE
Reorder the MADCTL bits to match the datasheet

### DIFF
--- a/st7735/lcd_st7735.c
+++ b/st7735/lcd_st7735.c
@@ -91,9 +91,9 @@ Result lcd_st7735_init(St7735Context *ctx, LCD_Interface *interface) {
 
 Result lcd_st7735_set_orientation(St7735Context *ctx, LCD_Orientation orientation) {
   const static uint8_t st7735_orientation_map[] = {
-      ST77_MADCTL_MY | ST77_MADCTL_MV,
-      ST77_MADCTL_MX | ST77_MADCTL_MV,
+      ST77_MADCTL_MV | ST77_MADCTL_MX,
       ST77_MADCTL_MX | ST77_MADCTL_MY,
+      ST77_MADCTL_MV | ST77_MADCTL_MY,
       0,
   };
 

--- a/st7735/lcd_st7735_cmds.h
+++ b/st7735/lcd_st7735_cmds.h
@@ -72,9 +72,9 @@ typedef enum {
 } ST7735_Cmd;
 
 typedef enum {
-  ST77_MADCTL_MX  = 0x01 << 7,  // Column Address Order
-  ST77_MADCTL_MV  = 0x01 << 6,  // Row/Column Exchange
-  ST77_MADCTL_MY  = 0x01 << 5,  // Row Address Order
+  ST77_MADCTL_MY  = 0x01 << 7,  // Row Address Order
+  ST77_MADCTL_MX  = 0x01 << 6,  // Column Address Order
+  ST77_MADCTL_MV  = 0x01 << 5,  // Row/Column Exchange
   ST77_MADCTL_ML  = 0x01 << 4,
   ST77_MADCTL_RGB = 0x01 << 3,
   ST77_MADCTL_MH  = 0x01 << 2


### PR DESCRIPTION
When none of the MV/X/Y bits is set, ie. no transformation, the top-left of the display is such that the ribbon cable of the LCD module enters the top edge, with column numbers increasing from left-to-right, and row numbers increasing upon moving further down the panel, away from the ribbon cable.

This PR corrects the declaration of the MV, MX and MY bits and updates the orientation settings accordingly so client code using the API should be unaffected.