### PR TITLE
Add functions to detect and apply offiset on using displays with a GM[2:0] misconfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,40 @@ void main(void){
 ## Configuration
 ### Endianess
 The driver assumes the platform is little-endian by default. If your platform is big-endian, define the macro LCD_IS_LITTLE_ENDIAN as 0 before including header or in the build system.
+
+## Detecting whether Offset is needed
+For some cheap displays, the controller resolution may be configured to 132x162 pixels, which exceeds the panel's actual resolution of 128x160 pixels. This can be detected automatically using the function `lcd_st7735_check_offset`.
+
+Note: The funciton  `lcd_st7735_check_offset` requires the callback `spi_read` to be implemented. 
+```C
+void main(void){
+    St7735Context ctx;
+    LCD_Interface interface = {
+        .handle = NULL,
+        .spi_write = spi_write,
+        .spi_read = spi_read,
+        .gpio_write = gpio_write,
+        .reset = reset,
+        .set_backlight_pwm = set_pwm,
+        .timer_delay = sleep_ms,
+    };
+
+    lcd_st7735_init(&ctx, &interface);
+
+    size_t w = 0, h = 0;
+    Result res = lcd_st7735_check_frame_buffer_resolution(&lcd, &w, &h);
+    if(res.code != 0){
+        LOG( "Warning: Unable to determine LCD offset. Try slower SPI clock.\r\n");
+    }else if(w != 160){
+        LOG("Offset needed");
+        lcd_st7735_set_frame_buffer_resolution(&lcd, w,h); 
+    }else{
+        LOG("No offset needed");
+    }
+
+    lcd_st7735_startup(&ctx);
+    lcd_st7735_fill_rectangle(&ctx, (LCD_rectangle){.origin = {.x = 0, .y = 0},
+            .end = {.x = 160, .y = 128}}, 0x00FF00);
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ static void set_pwm(void *handle, uint8_t pwm){
     //Code here.
 }
 
-static void sleep_ms(uint32_t ms){
+static void sleep_ms(void *handle, uint32_t ms){
     //Code here.
 }
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ void main(void){
     };
 
     lcd_st7735_init(&ctx, &interface);
+    lcd_st7735_startup(&ctx);
     lcd_st7735_fill_rectangle(&ctx, (LCD_rectangle){.origin = {.x = 0, .y = 0},
         .end = {.x = 160, .y = 128}}, 0x00FF00);
 }

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ void main(void){
     LCD_Interface interface = {
         .handle = NULL,
         .spi_write = spi_write,
+        .spi_read = NULL,
         .gpio_write = gpio_write,
         .reset = reset,
         .set_backlight_pwm = set_pwm,

--- a/core/lcd_base.c
+++ b/core/lcd_base.c
@@ -7,9 +7,11 @@
 
 #include "font.h"
 
-Result LCD_Init(LCD_Context *ctx, LCD_Interface *interface, uint32_t width, uint32_t height) {
-  ctx->interface = interface;
-  ctx->height    = height;
-  ctx->width     = width;
+Result LCD_Init(LCD_Context *ctx, LCD_Interface *interface, uint32_t width, uint32_t height,
+                LCD_Orientation orientation) {
+  ctx->interface   = interface;
+  ctx->height      = height;
+  ctx->width       = width;
+  ctx->orientation = orientation;
   return (Result){.code = 0};
 }

--- a/core/lcd_base.h
+++ b/core/lcd_base.h
@@ -120,6 +120,7 @@ typedef struct LCD_Context_st {
   const Font *font;          /*!< Font bitmaps*/
   uint32_t background_color; /*< Background color for font bitmaps */
   uint32_t foreground_color; /*< Foreground color for font bitmaps */
+  LCD_Orientation orientation;
 } LCD_Context;
 
 typedef struct LCD_Point_st {
@@ -138,7 +139,8 @@ typedef struct LCD_rectangle_st {
   size_t height;    /*!< Height from the origin.*/
 } LCD_rectangle;
 
-Result LCD_Init(LCD_Context *ctx, LCD_Interface *interface, uint32_t width, uint32_t height);
+Result LCD_Init(LCD_Context *ctx, LCD_Interface *interface, uint32_t width, uint32_t height,
+                LCD_Orientation orientation);
 
 static inline Result LCD_get_resolution(LCD_Context *ctx, size_t *height, size_t *width) {
   *height = ctx->height;

--- a/core/lcd_base.h
+++ b/core/lcd_base.h
@@ -31,6 +31,15 @@
 #define MAX(_A, _B) _A < _B ? _B : _A
 #endif
 
+#ifndef SWAP
+#define SWAP(_A, _B, TYPE)                                                                                             \
+  do {                                                                                                                 \
+    TYPE temp = (_A);                                                                                                  \
+    (_A)      = (_B);                                                                                                  \
+    (_B)      = temp;                                                                                                  \
+  } while (false)
+#endif
+
 typedef enum {
   LCD_Rotate0 = 0,
   LCD_Rotate90,

--- a/core/lcd_base.h
+++ b/core/lcd_base.h
@@ -91,7 +91,7 @@ typedef struct LCD_Interface_st {
    *
    * @param millis Time the delay should take in milliseconds.
    */
-  void (*timer_delay)(uint32_t millis);
+  void (*timer_delay)(void *handle, uint32_t millis);
 } LCD_Interface;
 
 typedef struct LCD_Context_st {

--- a/core/lcd_base.h
+++ b/core/lcd_base.h
@@ -139,6 +139,16 @@ static inline Result LCD_set_font(LCD_Context *ctx, const Font *font) {
   return (Result){.code = 0};
 }
 
+static inline Result LCD_get_font_size(LCD_Context *ctx, size_t *width, size_t *height) {
+  if (ctx->font == NULL) {
+    return (Result){.code = -1};
+  }
+
+  *height = ctx->font->height;
+  *width  = ctx->font->descriptor_table->width;
+  return (Result){.code = 0};
+}
+
 static inline uint16_t LCD_rgb24_to_bgr565(uint32_t rgb) {
   uint8_t r = (rgb >> 16) & 0xFF, g = (rgb >> 8) & 0xFF, b = rgb & 0xFF;
   uint16_t color = (uint16_t)(((b & 0xF8) << 8) | ((g & 0xFC) << 3) | (r >> 3));

--- a/core/lcd_base.h
+++ b/core/lcd_base.h
@@ -54,14 +54,26 @@ typedef struct LCD_Interface_st {
                    application. If not intended to be used it can be `NULL` */
 
   /**
-   * @brief Send data through spi interface.
+   * @brief Write bytes to the spi bus.
    *
    * @param data Pointer to data array to be sent.
-   * @param len Len of the data to be sent.
+   * @param len Length of the data to be sent.
    *
-   * @return the number of data sent.
+   * @return the number of bytes sent.
    */
   uint32_t (*spi_write)(void *handle, uint8_t *data, size_t len);
+
+  /**
+   * @brief Clock the spi and read the data.
+   *
+   * This function is only used in more complex operations, for basic use it can be NULL.
+   *
+   * @param data Pointer to array to store the data read.
+   * @param len Length of the data to be sent.
+   *
+   * @return the number of bytes read.
+   */
+  uint32_t (*spi_read)(void *handle, uint8_t *data, size_t len);
 
   /**
    * @brief Set the state of the chip select and D/C pins.
@@ -78,9 +90,7 @@ typedef struct LCD_Interface_st {
    */
   uint32_t (*reset)(void *handle);
 
-  /**
-   * @brief Apply a hardware reset to the display by toggling the pin.
-   * @param pwm Set the pwm (0-100).
+  /** @brief Apply a hardware reset to the display by toggling the pin. @param pwm Set the pwm (0-100).
    *
    * Note: Future use only.
    */

--- a/core/lcd_base.h
+++ b/core/lcd_base.h
@@ -47,9 +47,12 @@ typedef enum {
   LCD_Rotate270,
 } LCD_Orientation;
 
-typedef enum ErrorCode_e{
-  ErrorOk = 0,
-}ErrorCode;
+typedef enum ErrorCode_e {
+  ErrorOk              = 0,
+  ErrorNullArgs        = -1,
+  ErrorNullCallback    = -2,
+  ErrorOperationFailed = -3,
+} ErrorCode;
 
 typedef struct Result_st {
   int32_t code; /*!< See #ErrorCode */

--- a/core/lcd_base.h
+++ b/core/lcd_base.h
@@ -38,9 +38,12 @@ typedef enum {
   LCD_Rotate270,
 } LCD_Orientation;
 
-// TODO: Define error codes.
+typedef enum ErrorCode_e{
+  ErrorOk = 0,
+}ErrorCode;
+
 typedef struct Result_st {
-  int32_t code; /*!< */
+  int32_t code; /*!< See #ErrorCode */
 } Result;
 
 /**

--- a/st7735/lcd_st7735.c
+++ b/st7735/lcd_st7735.c
@@ -52,6 +52,11 @@ static void run_script(St7735Context *ctx, const uint8_t *addr) {
 }
 
 static void set_address(St7735Context *ctx, uint32_t x0, uint32_t y0, uint32_t x1, uint32_t y1) {
+  x0 += ctx->row_offset;
+  x1 += ctx->row_offset;
+  y0 += ctx->col_offset;
+  y1 += ctx->col_offset;
+
   {
     uint8_t coordinate[4] = {(uint8_t)(x0 >> 8), (uint8_t)x0, (uint8_t)(x1 >> 8), (uint8_t)x1};
     write_command(ctx, ST7735_CASET);  // Column addr set
@@ -80,6 +85,7 @@ static void write_register(St7735Context *ctx, uint8_t addr, uint8_t value) {
 Result lcd_st7735_init(St7735Context *ctx, LCD_Interface *interface) {
   LCD_Init(&ctx->parent, interface, 160, 128);
   lcd_st7735_set_font_colors(ctx, 0xFFFFFF, 0x000000);
+  ctx->col_offset = ctx->row_offset = 0;
 
   int32_t result = 0;
 

--- a/st7735/lcd_st7735.c
+++ b/st7735/lcd_st7735.c
@@ -52,19 +52,20 @@ static void run_script(St7735Context *ctx, const uint8_t *addr) {
 }
 
 static void set_address(St7735Context *ctx, uint32_t x0, uint32_t y0, uint32_t x1, uint32_t y1) {
-  uint32_t coordinate = 0;
-
-  coordinate = (uint32_t)(x0 << 8 | x1 << 24);
-  write_command(ctx, ST7735_CASET);  // Column addr set
-  ctx->parent.interface->gpio_write(ctx->parent.interface->handle, false, true);
-  write_buffer(ctx, (uint8_t *)&coordinate, sizeof(coordinate));
-  ctx->parent.interface->gpio_write(ctx->parent.interface->handle, true, true);
-
-  coordinate = (uint32_t)(y0 << 8 | y1 << 24);
-  write_command(ctx, ST7735_RASET);  // Row addr set
-  ctx->parent.interface->gpio_write(ctx->parent.interface->handle, false, true);
-  write_buffer(ctx, (uint8_t *)&coordinate, sizeof(coordinate));
-  ctx->parent.interface->gpio_write(ctx->parent.interface->handle, true, true);
+  {
+    uint8_t coordinate[4] = {(uint8_t)(x0 >> 8), (uint8_t)x0, (uint8_t)(x1 >> 8), (uint8_t)x1};
+    write_command(ctx, ST7735_CASET);  // Column addr set
+    ctx->parent.interface->gpio_write(ctx->parent.interface->handle, false, true);
+    write_buffer(ctx, coordinate, sizeof(coordinate));
+    ctx->parent.interface->gpio_write(ctx->parent.interface->handle, true, true);
+  }
+  {
+    uint8_t coordinate[4] = {(uint8_t)(y0 >> 8), (uint8_t)y0, (uint8_t)(y1 >> 8), (uint8_t)y1};
+    write_command(ctx, ST7735_RASET);  // Row addr set
+    ctx->parent.interface->gpio_write(ctx->parent.interface->handle, false, true);
+    write_buffer(ctx, coordinate, sizeof(coordinate));
+    ctx->parent.interface->gpio_write(ctx->parent.interface->handle, true, true);
+  }
 
   write_command(ctx, ST7735_RAMWR);  // write to RAM
 }

--- a/st7735/lcd_st7735.c
+++ b/st7735/lcd_st7735.c
@@ -23,7 +23,9 @@ static void write_buffer(St7735Context *ctx, const uint8_t *buffer, size_t lengt
   }
 }
 
-static void delay(St7735Context *ctx, uint32_t millisecond) { ctx->parent.interface->timer_delay(millisecond); }
+static inline void delay(St7735Context *ctx, uint32_t millisecond) {
+  ctx->parent.interface->timer_delay(ctx->parent.interface->handle, millisecond);
+}
 
 static void run_script(St7735Context *ctx, const uint8_t *addr) {
   uint8_t numCommands, numArgs;

--- a/st7735/lcd_st7735.c
+++ b/st7735/lcd_st7735.c
@@ -96,7 +96,7 @@ Result lcd_st7735_set_orientation(St7735Context *ctx, LCD_Orientation orientatio
       ST77_MADCTL_MV | ST77_MADCTL_MY,
       0,
   };
-  const static uint8_t st7735_width_map[] = {160, 128, 160, 128};
+  const static uint8_t st7735_width_map[]  = {160, 128, 160, 128};
   const static uint8_t st7735_height_map[] = {128, 160, 128, 160};
 
   write_register(ctx, ST7735_MADCTL, st7735_orientation_map[orientation] | ST77_MADCTL_RGB);
@@ -283,11 +283,5 @@ Result lcd_st7735_rgb565_finish(St7735Context *ctx) {
   ctx->parent.interface->gpio_write(ctx->parent.interface->handle, true, true);
   return (Result){.code = 0};
 }
-
-extern Result lcd_st7735_set_font(St7735Context *ctx, const Font *font);
-
-extern Result lcd_st7735_set_font_colors(St7735Context *ctx, uint32_t background_color, uint32_t foreground_color);
-
-extern Result lcd_st7735_get_resolution(St7735Context *ctx, size_t *height, size_t *width);
 
 Result lcd_st7735_close(St7735Context *ctx) { return (Result){.code = 0}; }

--- a/st7735/lcd_st7735.c
+++ b/st7735/lcd_st7735.c
@@ -114,6 +114,10 @@ Result lcd_st7735_init(St7735Context *ctx, LCD_Interface *interface) {
   lcd_st7735_set_font_colors(ctx, 0xFFFFFF, 0x000000);
   ctx->col_offset = ctx->row_offset = 0;
 
+  return (Result){.code = 0};
+}
+
+Result lcd_st7735_startup(St7735Context *ctx) {
   int32_t result = 0;
 
   run_script(ctx, init_script_b);

--- a/st7735/lcd_st7735.c
+++ b/st7735/lcd_st7735.c
@@ -85,7 +85,7 @@ static void write_register(St7735Context *ctx, uint8_t addr, uint8_t value) {
 }
 
 Result lcd_st7735_init(St7735Context *ctx, LCD_Interface *interface) {
-  LCD_Init(&ctx->parent, interface, 160, 128);
+  LCD_Init(&ctx->parent, interface, 160, 128, LCD_Rotate0);
   lcd_st7735_set_font_colors(ctx, 0xFFFFFF, 0x000000);
   ctx->col_offset = ctx->row_offset = 0;
 

--- a/st7735/lcd_st7735.c
+++ b/st7735/lcd_st7735.c
@@ -293,4 +293,14 @@ Result lcd_st7735_rgb565_finish(St7735Context *ctx) {
   return (Result){.code = 0};
 }
 
+Result lcd_st7735_reset(St7735Context *ctx, bool hw) {
+  if (hw && ctx->parent.interface->reset) {
+    ctx->parent.interface->reset(ctx->parent.interface->handle);
+  } else {
+    write_command(ctx, ST7735_SWRESET);
+    delay(ctx, 120);
+  }
+  return (Result){.code = 0};
+}
+
 Result lcd_st7735_close(St7735Context *ctx) { return (Result){.code = 0}; }

--- a/st7735/lcd_st7735.h
+++ b/st7735/lcd_st7735.h
@@ -48,6 +48,16 @@ typedef struct stSt7735Context {
 Result lcd_st7735_init(St7735Context *ctx, LCD_Interface *interface);
 
 /**
+ * @brief Reset the lcd controller.
+ *
+ * @param ctx Handle.
+ * @param hw If `true` perform a hardware reset (if the callback is registered), otherwise send a software reset
+ * command.
+ * @return Result of the operation.
+ */
+Result lcd_st7735_reset(St7735Context *ctx, bool hw);
+
+/**
  * @brief Clean the screen by drawing a write rectangle.
  *
  * @param ctx Handle.

--- a/st7735/lcd_st7735.h
+++ b/st7735/lcd_st7735.h
@@ -19,6 +19,10 @@ typedef struct stSt7735Context {
   LCD_Context parent; /*!< Base context*/
   uint32_t rgb_background;
   uint32_t rgb_foreground;
+  // Custom offsets are necessary for some cheap displays due to controller configurations that exceed the panel's
+  // actual resolution.
+  size_t col_offset;
+  size_t row_offset;
 } St7735Context;
 
 /**
@@ -214,5 +218,15 @@ Result lcd_st7735_set_orientation(St7735Context *ctx, LCD_Orientation orientatio
  * @return Result of the operation.
  */
 Result lcd_st7735_close(St7735Context *ctx);
+
+/**
+ * @brief Set the controller frame buffer resolution configured via GM[2:0].
+ * This function is used to workaround a mismatch between the LCD panel resolution and the frame buffer resolution.
+ * For some cheap displays, the controller resolution may be configured to 162x132 pixels, that exceeds the panel's
+ * resolution of 160x128 pixels.
+ * @param width The frame buffer width in pixels.
+ * @param height The frame buffer height in pixels.
+ */
+void lcd_st7735_set_frame_buffer_resolution(St7735Context *ctx, size_t width, size_t height);
 
 #endif

--- a/st7735/lcd_st7735.h
+++ b/st7735/lcd_st7735.h
@@ -247,4 +247,14 @@ Result lcd_st7735_close(St7735Context *ctx);
  */
 void lcd_st7735_set_frame_buffer_resolution(St7735Context *ctx, size_t width, size_t height);
 
+/**
+ * @brief Trying to detect the GM[2:0] pad configuration and return the configured resolution.
+ *
+ * This function requires the `spi_read` callback to be implemented.
+ *
+ * @param[out] width The width in pixels.
+ * @param[out] height The height in pixels.
+ * @return Result of the operation.
+ */
+Result lcd_st7735_check_frame_buffer_resolution(St7735Context *lcd, size_t *width, size_t *height);
 #endif

--- a/st7735/lcd_st7735.h
+++ b/st7735/lcd_st7735.h
@@ -26,7 +26,7 @@ typedef struct stSt7735Context {
 } St7735Context;
 
 /**
- * @brief Initialize the LCD driver.
+ * @brief Initialize the LCD driver interfaces.
  *
  * Example:
  * ```C
@@ -46,6 +46,14 @@ typedef struct stSt7735Context {
  * @return Result of the operation.
  */
 Result lcd_st7735_init(St7735Context *ctx, LCD_Interface *interface);
+
+/**
+ * @brief Initialize the LCD controller, this function must me called only after `lcd_st7735_init`.
+ *
+ * @param ctx Handle.
+ * @return Result of the operation.the operation.
+ */
+Result lcd_st7735_startup(St7735Context *ctx);
 
 /**
  * @brief Reset the lcd controller.

--- a/st7735/lcd_st7735.h
+++ b/st7735/lcd_st7735.h
@@ -14,7 +14,6 @@
 
 /**
  * @brief Context struct.
- *
  */
 typedef struct stSt7735Context {
   LCD_Context parent; /*!< Base context*/
@@ -60,7 +59,7 @@ Result lcd_st7735_clean(St7735Context *ctx);
  * @param[out] width Pointer to receive the width in pixels.
  * @return Result of the operation.
  */
-inline Result lcd_st7735_get_resolution(St7735Context *ctx, size_t *height, size_t *width) {
+static inline Result lcd_st7735_get_resolution(St7735Context *ctx, size_t *height, size_t *width) {
   return LCD_get_resolution(&ctx->parent, height, width);
 }
 


### PR DESCRIPTION
For some cheap displays, the controller resolution may be configured to 132x162 pixels, that exceeds the panel's of 128x160 pixels. 

This PR changes the driver API to allow the application to deal with these displays.
